### PR TITLE
Update references to project name/url

### DIFF
--- a/plugin-self-test
+++ b/plugin-self-test
@@ -15,6 +15,6 @@ else
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer $GITHUB_TOKEN"\
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    https://api.github.com/repos/gradle/github-dependency-extractor/dependency-graph/snapshots \
+    https://api.github.com/repos/gradle/github-dependency-graph-gradle-plugin/dependency-graph/snapshots \
     -d @build/reports/github-dependency-graph-plugin/github-dependency-snapshot.json
 fi

--- a/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/BaseExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/BaseExtractorTest.groovy
@@ -136,7 +136,7 @@ abstract class BaseExtractorTest extends Specification {
         assert detector.name.contains("Gradle")
         assert detector.version != null
         assert detector.version != ""
-        assert detector.url == "https://github.com/gradle/github-dependency-extractor"
+        assert detector.url == "https://github.com/gradle/github-dependency-graph-gradle-plugin"
         return json["manifests"] as Map
     }
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -67,8 +67,8 @@ tasks.test {
 tasks.withType<Jar>().configureEach {
     manifest {
         attributes["Implementation-Version"] = archiveVersion.get()
-        attributes["Implementation-Title"] = "Gradle GitHub Dependency Extractor"
-        attributes["Implementation-Vendor"] = "Gradle GitHub Dependency Extractor"
+        attributes["Implementation-Title"] = "GitHub Dependency Graph Gradle Plugin"
+        attributes["Implementation-Vendor"] = "Gradle Inc"
     }
 }
 
@@ -133,8 +133,8 @@ tasks.named("jar").configure {
  * Configuration for publishing the plugin, locally and to the Gradle Plugin Portal.
  */
 gradlePlugin {
-    website.set("https://github.com/gradle/github-dependency-extractor")
-    vcsUrl.set("https://github.com/gradle/github-dependency-extractor")
+    website.set("https://github.com/gradle/github-dependency-graph-gradle-plugin")
+    vcsUrl.set("https://github.com/gradle/github-dependency-graph-gradle-plugin")
 
     plugins {
         create("dependencyGraphPlugin") {
@@ -195,7 +195,7 @@ val createReleaseTag = tasks.register<CreateGitTag>("createReleaseTag") {
 githubRelease {
     setToken(System.getenv("GITHUB_DEPENDENCY_GRAPH_GIT_TOKEN") ?: "")
     owner.set("gradle")
-    repo.set("github-dependency-extractor")
+    repo.set("github-dependency-graph-gradle-plugin")
     releaseName.set(releaseVersion)
     tagName.set(releaseTag)
     prerelease.set(true)

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
@@ -192,7 +192,7 @@ abstract class DependencyExtractor :
         if (thrownExceptions.isNotEmpty()) {
             throw DefaultMultiCauseException(
                     "The ${GitHubDependencyGraphPlugin::class.simpleName} plugin encountered errors while extracting dependencies. " +
-                            "Please report this issue at: https://github.com/gradle/github-dependency-extractor/issues",
+                            "Please report this issue at: https://github.com/gradle/github-dependency-graph-gradle-plugin/issues",
                     thrownExceptions
             )
         }
@@ -201,7 +201,7 @@ abstract class DependencyExtractor :
         } catch (e: RuntimeException) {
             throw GradleException(
                     "The ${GitHubDependencyGraphPlugin::class.simpleName} plugin encountered errors while writing the dependency snapshot json file. " +
-                            "Please report this issue at: https://github.com/gradle/github-dependency-extractor/issues",
+                            "Please report this issue at: https://github.com/gradle/github-dependency-graph-gradle-plugin/issues",
                     e
             )
         }

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/json/GitHubDetector.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/json/GitHubDetector.kt
@@ -3,5 +3,5 @@ package org.gradle.github.dependencygraph.internal.json
 data class GitHubDetector(
     val name: String = GitHubDetector::class.java.`package`.implementationTitle,
     val version: String = GitHubDetector::class.java.`package`.implementationVersion,
-    val url: String = "https://github.com/gradle/github-dependency-extractor"
+    val url: String = "https://github.com/gradle/github-dependency-graph-gradle-plugin"
 )


### PR DESCRIPTION
The GitHub project has been renamed to `gradle/github-dependency-graph-gradle-plugin`. This commit updates all references to this name.