### PR TITLE
Avoid an intermediate `toURL()` conversion

### DIFF
--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
@@ -162,7 +162,6 @@ abstract class DependencyExtractor :
                 ?.find { it.id == id }
                 ?.properties
                 ?.let { it["URL"] as? URI }
-                ?.toURL()
                 ?.toString()
         }
 

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
@@ -83,7 +83,7 @@ abstract class DependencyExtractor :
     }
 
     private fun extractProjects(
-        details: LoadProjectsBOT.Details,
+        @Suppress("UNUSED_PARAMETER") details: LoadProjectsBOT.Details,
         result: LoadProjectsBOT.Result
     ) {
         tailrec fun recursivelyExtractProjects(projects: Set<LoadProjectsBOT.Result.Project>) {


### PR DESCRIPTION
The final string representation should be the same when directly using the URI instead. Also, constructing a URL might actually imply network requests which should be avoided here (also see [1] for why URL constructors were deprecated in Java 20).

[1]: https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/net/URL.html#constructor-deprecation