### PR TITLE
Omit repository_url for Maven central

### DIFF
--- a/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/BaseExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/BaseExtractorTest.groovy
@@ -121,8 +121,13 @@ abstract class BaseExtractorTest extends Specification {
     }
 
     protected String purlFor(String group, String module, String version) {
-        // NOTE: Don't use this in production, this is purely for test code. The escaping here may be insufficient.
-        String repositoryUrlEscaped = URLEncoder.encode(mavenRepo.rootDir.toURI().toASCIIString(), "UTF-8")
+        // NOTE: Don't use this in production, this is purely for test code. The escaping here may be insufficient
+        def repositoryUrl = mavenRepo.rootDir.toURI().toASCIIString()
+        // Remove trailing '/' to be consistent with production code
+        if (repositoryUrl.endsWith("/")) {
+            repositoryUrl = repositoryUrl.substring(0, repositoryUrl.length() - 1)
+        }
+        String repositoryUrlEscaped = URLEncoder.encode(repositoryUrl, "UTF-8")
         return "pkg:maven/${group}/${module}@${version}?repository_url=$repositoryUrlEscaped"
     }
 

--- a/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/BaseExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/BaseExtractorTest.groovy
@@ -125,7 +125,7 @@ abstract class BaseExtractorTest extends Specification {
         def repositoryUrl = mavenRepo.rootDir.toURI().toASCIIString()
         // Remove trailing '/' to be consistent with production code
         if (repositoryUrl.endsWith("/")) {
-            repositoryUrl = repositoryUrl.substring(0, repositoryUrl.length() - 1)
+            repositoryUrl = repositoryUrl.dropRight(1)
         }
         String repositoryUrlEscaped = URLEncoder.encode(repositoryUrl, "UTF-8")
         return "pkg:maven/${group}/${module}@${version}?repository_url=$repositoryUrlEscaped"

--- a/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/SampleProjectDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/SampleProjectDependencyExtractorTest.groovy
@@ -28,15 +28,25 @@ class SampleProjectDependencyExtractorTest extends BaseExtractorTest {
         ])
 
         def projectManifest = jsonManifest("project :")
-        def projectDependencies = (projectManifest.resolved as Map).keySet()
-        projectDependencies.containsAll([
-            "com.diffplug.spotless:spotless-plugin-gradle:4.5.1", // 'plugins' dependency
-            "com.diffplug.durian:durian-core:1.2.0", // transitive 'plugins' dependency
+        def projectDependencies = projectManifest.resolved as Map<String, Map>
+
+        [   // plugin dependencies
+            "com.diffplug.spotless:spotless-plugin-gradle:4.5.1",
+            "com.diffplug.durian:durian-core:1.2.0",
+        ].forEach {
+            assert projectDependencies.containsKey(it)
+            assert (projectDependencies[it].package_url as String).endsWith("?repository_url=https%3A%2F%2Fplugins.gradle.org%2Fm2")
+        }
+
+        [   // regular dependencies
             "org.apache.commons:commons-math3:3.6.1", // 'api' dependency
             "com.google.guava:guava:31.1-jre", // 'implementation' dependency
             "com.google.guava:failureaccess:1.0.1", // transitive 'implementation' dependency
             "org.junit.jupiter:junit-jupiter:5.9.1" // testImplementation dependency
-        ])
+        ].forEach {
+            assert projectDependencies.containsKey(it)
+            assert !(projectDependencies[it].package_url as String).contains("?repository_url") // Maven repo default is not included
+        }
     }
 
     def "check java-multi-project sample"() {

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
@@ -163,6 +163,7 @@ abstract class DependencyExtractor :
                 ?.properties
                 ?.let { it["URL"] as? URI }
                 ?.toString()
+                ?.removeSuffix("/")
         }
 
         /**

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/GitHubRepositorySnapshotBuilder.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/GitHubRepositorySnapshotBuilder.kt
@@ -8,6 +8,8 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 
+private const val DEFAULT_MAVEN_REPOSITORY_URL = "https://repo.maven.apache.org/maven2"
+
 class GitHubRepositorySnapshotBuilder(
     private val dependencyGraphJobCorrelator: String,
     private val dependencyGraphJobId: String,
@@ -128,7 +130,7 @@ class GitHubRepositorySnapshotBuilder(
                 .withName(component.coordinates.module)
                 .withVersion(component.coordinates.version)
                 .also {
-                    if (component.repositoryUrl != null) {
+                    if (component.repositoryUrl != null && component.repositoryUrl != DEFAULT_MAVEN_REPOSITORY_URL) {
                         it.withQualifier("repository_url", component.repositoryUrl)
                     }
                 }


### PR DESCRIPTION
The maven central repo (https://repo.maven.apache.org/m2) is the default repository URL for any maven PURLs.
For dependencies resolved from Maven central, a repository_url value is no longer included in the generated PURL.

Fixes #43 