### PR TITLE
General refactoring

### DIFF
--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/BuildLayout.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/BuildLayout.kt
@@ -1,0 +1,28 @@
+package org.gradle.github.dependencygraph.internal
+
+import org.gradle.github.dependencygraph.internal.json.GitHubManifestFile
+import org.gradle.github.dependencygraph.internal.model.ResolvedConfiguration
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
+
+class BuildLayout(val gitWorkspaceDirectory: Path) {
+    private val projectToRelativeBuildFile = ConcurrentHashMap<String, String>()
+
+    fun addProject(identityPath: String, buildFileAbsolutePath: String) {
+        val buildFilePath = Paths.get(buildFileAbsolutePath)
+        projectToRelativeBuildFile[identityPath] = gitWorkspaceDirectory.relativize(buildFilePath).toString()
+    }
+
+    private fun buildFileForProject(identityPath: String): GitHubManifestFile? {
+        return projectToRelativeBuildFile[identityPath]?.let {
+            // Cleanup the path for Windows systems
+            val sourceLocation = it.replace('\\', '/')
+            GitHubManifestFile(sourceLocation = sourceLocation)
+        }
+    }
+
+    fun getBuildFile(resolvedConfiguration: ResolvedConfiguration): GitHubManifestFile? {
+        return buildFileForProject(resolvedConfiguration.identityPath)
+    }
+}

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyExtractor.kt
@@ -120,8 +120,8 @@ abstract class DependencyExtractor :
         val resolvedConfiguration = ResolvedConfiguration(rootId, rootPath)
 
         for (directDependency in getResolvedDependencies(rootComponent)) {
-            val directDep = createComponentNode(componentId(directDependency), directDependency, repositoryLookup)
-            resolvedConfiguration.addDirectDependency(directDep)
+            val directDep = createComponentNode(componentId(directDependency), true, directDependency, repositoryLookup)
+            resolvedConfiguration.addDependency(directDep)
 
             walkComponentDependencies(directDependency, repositoryLookup, resolvedConfiguration)
         }
@@ -138,7 +138,7 @@ abstract class DependencyExtractor :
         for (dependencyComponent in dependencyComponents) {
             val dependencyId = componentId(dependencyComponent)
             if (!resolvedConfiguration.hasDependency(dependencyId)) {
-                val dependencyNode = createComponentNode(dependencyId, dependencyComponent, repositoryLookup)
+                val dependencyNode = createComponentNode(dependencyId, false, dependencyComponent, repositoryLookup)
                 resolvedConfiguration.addDependency(dependencyNode)
 
                 walkComponentDependencies(dependencyComponent, repositoryLookup, resolvedConfiguration)
@@ -150,10 +150,10 @@ abstract class DependencyExtractor :
         return component.dependencies.filterIsInstance<ResolvedDependencyResult>().map { it.selected }.filter { it != component }
     }
 
-    private fun createComponentNode(componentId: String, component: ResolvedComponentResult, repositoryLookup: RepositoryUrlLookup): ResolvedComponent {
+    private fun createComponentNode(componentId: String, direct: Boolean, component: ResolvedComponentResult, repositoryLookup: RepositoryUrlLookup): ResolvedComponent {
         val componentDependencies = component.dependencies.filterIsInstance<ResolvedDependencyResult>().map { componentId(it.selected) }
         val repositoryUrl = repositoryLookup.doLookup(component)
-        return ResolvedComponent(componentId, coordinates(component), repositoryUrl, componentDependencies)
+        return ResolvedComponent(componentId, direct, coordinates(component), repositoryUrl, componentDependencies)
     }
 
     private fun componentId(component: ResolvedComponentResult): String {

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyFileWriter.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/DependencyFileWriter.kt
@@ -7,7 +7,7 @@ import java.io.File
 class DependencyFileWriter(val manifestFile: File) {
     private var writtenFile: Boolean = false
 
-    fun writeDependencyManifest(graph: GitHubRepositorySnapshot): File {
+    fun writeDependencySnapshot(graph: GitHubRepositorySnapshot): File {
         if (writtenFile) {
             return manifestFile
         }

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/GitHubRepositorySnapshotBuilder.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/GitHubRepositorySnapshotBuilder.kt
@@ -31,7 +31,7 @@ class GitHubRepositorySnapshotBuilder(
             val manifestName = manifestName(resolutionRoot)
             val dependencyCollector = manifestDependencies.getOrPut(manifestName) { DependencyCollector() }
             for (component in resolutionRoot.allDependencies) {
-                dependencyCollector.addResolved(component, resolutionRoot)
+                dependencyCollector.addResolved(component)
             }
 
             // If not assigned to a project, assume the root project for the assigned build.
@@ -65,11 +65,11 @@ class GitHubRepositorySnapshotBuilder(
         /**
          * Merge each resolved component with the same ID into a single GitHubDependency.
          */
-        fun addResolved(component: ResolvedComponent, resolvedConfiguration: ResolvedConfiguration) {
+        fun addResolved(component: ResolvedComponent) {
             val dep = dependencyBuilders.getOrPut(component.id) {
                 GitHubDependencyBuilder(packageUrl(component))
             }
-            dep.addRelationship(relationship(resolvedConfiguration, component))
+            dep.addRelationship(relationship(component))
             dep.addDependencies(component.dependencies)
         }
 
@@ -82,8 +82,8 @@ class GitHubRepositorySnapshotBuilder(
             }
         }
 
-        private fun relationship(resolvedConfiguration: ResolvedConfiguration, component: ResolvedComponent) =
-            if (resolvedConfiguration.directDependencies.contains(component)) GitHubDependency.Relationship.direct else GitHubDependency.Relationship.indirect
+        private fun relationship(component: ResolvedComponent) =
+            if (component.direct) GitHubDependency.Relationship.direct else GitHubDependency.Relationship.indirect
 
         private fun packageUrl(component: ResolvedComponent) =
             PackageURLBuilder

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedComponent.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedComponent.kt
@@ -1,3 +1,3 @@
 package org.gradle.github.dependencygraph.internal.model
 
-data class ResolvedComponent(val id: String, val coordinates: ComponentCoordinates, val repositoryUrl: String?, val dependencies: List<String>)
+data class ResolvedComponent(val id: String, val direct: Boolean, val coordinates: ComponentCoordinates, val repositoryUrl: String?, val dependencies: List<String>)

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedConfiguration.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedConfiguration.kt
@@ -2,13 +2,7 @@ package org.gradle.github.dependencygraph.internal.model
 
 data class ResolvedConfiguration(val id: String,
                                  val identityPath: String,
-                                 val directDependencies: MutableList<ResolvedComponent> = mutableListOf(),
                                  val allDependencies: MutableList<ResolvedComponent> = mutableListOf()) {
-    fun addDirectDependency(component: ResolvedComponent) {
-        directDependencies.add(component)
-        allDependencies.add(component)
-    }
-
     fun addDependency(component: ResolvedComponent) {
         allDependencies.add(component)
     }

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedConfiguration.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedConfiguration.kt
@@ -1,11 +1,19 @@
 package org.gradle.github.dependencygraph.internal.model
 
-data class ResolvedConfiguration(val buildPath: String, val identityPath: String?, val configName: String, val components: MutableList<ResolvedComponent> = mutableListOf()) {
-    fun hasComponent(componentId: String): Boolean {
-        return components.map { it.id }.contains(componentId)
+data class ResolvedConfiguration(val id: String,
+                                 val identityPath: String,
+                                 val directDependencies: MutableList<ResolvedComponent> = mutableListOf(),
+                                 val allDependencies: MutableList<ResolvedComponent> = mutableListOf()) {
+    fun addDirectDependency(component: ResolvedComponent) {
+        directDependencies.add(component)
+        allDependencies.add(component)
     }
 
-    fun getRootComponent(): ResolvedComponent {
-        return components.first()
+    fun addDependency(component: ResolvedComponent) {
+        allDependencies.add(component)
+    }
+
+    fun hasDependency(componentId: String): Boolean {
+        return allDependencies.map { it.id }.contains(componentId)
     }
 }


### PR DESCRIPTION
- Move core functionality out of GitHub builder
- Remove unused configuration name from ResolvedConfiguration
- Determine the id/name of a resolution root when first constructing
- Remove rootComponent from ResolutionRoot
- Simplify GitHub builder
- Store the 'direct' flag directly in `ResolvedComponent` rather than calculating it on demand.