### PR TITLE
Report dependencies by declaring project

### DIFF
--- a/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/PluginDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/PluginDependencyExtractorTest.groovy
@@ -54,9 +54,8 @@ class PluginDependencyExtractorTest extends BaseExtractorTest {
         run()
 
         then:
-        manifestNames == ["build :", "project :", "project :buildSrc", "project :buildSrc:a"]
+        manifestNames == ["build :", "project :buildSrc", "project :buildSrc:a"]
         manifestHasSettingsPlugin("build :")
-        manifestIsEmpty("project :")
         manifestHasPlugin1("project :buildSrc")
         manifestHasPlugin2("project :buildSrc:a")
     }
@@ -72,9 +71,8 @@ class PluginDependencyExtractorTest extends BaseExtractorTest {
         run()
 
         then:
-        manifestNames == ["build :", "project :", "project :included-child", "project :included-child:a"]
+        manifestNames == ["build :", "project :included-child", "project :included-child:a"]
         manifestHasSettingsPlugin("build :")
-        manifestIsEmpty("project :")
         manifestHasPlugin1("project :included-child")
         manifestHasPlugin2("project :included-child:a")
     }
@@ -94,9 +92,8 @@ class PluginDependencyExtractorTest extends BaseExtractorTest {
         run()
 
         then:
-        manifestNames == ["build :", "project :", "project :included-plugin", "project :included-plugin:a"]
+        manifestNames == ["build :", "project :included-plugin", "project :included-plugin:a"]
         manifestHasSettingsPlugin("build :")
-        manifestIsEmpty("project :")
         manifestHasPlugin1("project :included-plugin")
         manifestHasPlugin2("project :included-plugin:a")
     }

--- a/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/SingleProjectDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/SingleProjectDependencyExtractorTest.groovy
@@ -329,7 +329,7 @@ class SingleProjectDependencyExtractorTest extends BaseExtractorTest {
         run()
 
         then:
-        manifestNames == ["build :", "project :"]
+        manifestNames == ["build :"]
         def settingsManifest = gitHubManifest("build :")
         settingsManifest.sourceFile == "build.gradle"
 
@@ -412,7 +412,7 @@ class SingleProjectDependencyExtractorTest extends BaseExtractorTest {
         run()
 
         then:
-        manifestNames == ["build :", "project :"]
+        manifestNames == ["build :"]
         def buildManifest = gitHubManifest("build :")
         buildManifest.sourceFile == "build.gradle"
         buildManifest.assertResolved([
@@ -425,9 +425,5 @@ class SingleProjectDependencyExtractorTest extends BaseExtractorTest {
                 relationship: "indirect"
             ]
         ])
-
-        def manifest = gitHubManifest("project :")
-        manifest.sourceFile == "build.gradle"
-        manifest.assertResolved([:])
     }
 }

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/BuildLayout.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/BuildLayout.kt
@@ -1,7 +1,7 @@
 package org.gradle.github.dependencygraph.internal
 
 import org.gradle.github.dependencygraph.internal.json.GitHubManifestFile
-import org.gradle.github.dependencygraph.internal.model.ResolvedConfiguration
+import org.gradle.github.dependencygraph.internal.model.ResolutionRoot
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
@@ -22,7 +22,7 @@ class BuildLayout(val gitWorkspaceDirectory: Path) {
         }
     }
 
-    fun getBuildFile(resolvedConfiguration: ResolvedConfiguration): GitHubManifestFile? {
-        return buildFileForProject(resolvedConfiguration.identityPath)
+    fun getBuildFile(rootComponent: ResolutionRoot): GitHubManifestFile? {
+        return buildFileForProject(rootComponent.path)
     }
 }

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/GitHubRepositorySnapshotBuilder.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/GitHubRepositorySnapshotBuilder.kt
@@ -61,7 +61,7 @@ class GitHubRepositorySnapshotBuilder(
         return dependency.id.startsWith("project ")
     }
 
-    private class DependencyCollector(var rootComponent: ResolutionRoot) {
+    private class DependencyCollector(val rootComponent: ResolutionRoot) {
         private val dependencyBuilders: MutableMap<String, GitHubDependencyBuilder> = mutableMapOf()
 
         /**

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/GitHubRepositorySnapshotBuilder.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/GitHubRepositorySnapshotBuilder.kt
@@ -4,6 +4,7 @@ import com.github.packageurl.PackageURLBuilder
 import org.gradle.github.dependencygraph.internal.model.ResolvedComponent
 import org.gradle.github.dependencygraph.internal.model.ResolvedConfiguration
 import org.gradle.github.dependencygraph.internal.json.*
+import org.gradle.github.dependencygraph.internal.model.ResolutionRoot
 
 private const val DEFAULT_MAVEN_REPOSITORY_URL = "https://repo.maven.apache.org/maven2"
 
@@ -25,25 +26,25 @@ class GitHubRepositorySnapshotBuilder(
 
     fun build(resolvedConfigurations: MutableList<ResolvedConfiguration>, buildLayout: BuildLayout): GitHubRepositorySnapshot {
         val manifestDependencies = mutableMapOf<String, DependencyCollector>()
-        val manifestFiles = mutableMapOf<String, GitHubManifestFile?>()
 
         for (resolutionRoot in resolvedConfigurations) {
-            val manifestName = manifestName(resolutionRoot)
-            val dependencyCollector = manifestDependencies.getOrPut(manifestName) { DependencyCollector() }
-            for (component in resolutionRoot.allDependencies) {
-                dependencyCollector.addResolved(component)
-            }
+            for (dependency in resolutionRoot.allDependencies) {
+                // Ignore project dependencies (transitive deps of projects will be reported with project)
+                if (isProject(dependency)) continue
 
-            // If not assigned to a project, assume the root project for the assigned build.
-            manifestFiles.putIfAbsent(manifestName, buildLayout.getBuildFile(resolutionRoot))
+                val rootComponent = dependency.rootComponent
+                val dependencyCollector = manifestDependencies.getOrPut(rootComponent.id) { DependencyCollector(rootComponent) }
+                dependencyCollector.addResolved(dependency)
+            }
         }
 
         val manifests = manifestDependencies.mapValues { (name, collector) ->
+            val manifestFile = buildLayout.getBuildFile(collector.rootComponent)
 
             GitHubManifest(
                 name,
                 collector.getDependencies(),
-                manifestFiles[name]
+                manifestFile
             )
         }
         return GitHubRepositorySnapshot(
@@ -55,11 +56,12 @@ class GitHubRepositorySnapshotBuilder(
         )
     }
 
-    private fun manifestName(root: ResolvedConfiguration): String {
-        return root.id
+    // TODO:DAZ Model this better
+    private fun isProject(dependency: ResolvedComponent): Boolean {
+        return dependency.id.startsWith("project ")
     }
 
-    private class DependencyCollector() {
+    private class DependencyCollector(var rootComponent: ResolutionRoot) {
         private val dependencyBuilders: MutableMap<String, GitHubDependencyBuilder> = mutableMapOf()
 
         /**

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolutionRoot.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolutionRoot.kt
@@ -1,0 +1,9 @@
+package org.gradle.github.dependencygraph.internal.model
+
+/**
+ * A root component in dependency resolution, this represents a component that "owns" or declares
+ * dependencies within a given resolution.
+ * In most cases, this will be the project component that declares the dependency, but for certain resolutions
+ * this component will represent an overall build.
+ */
+data class ResolutionRoot(val id: String, val path: String)

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedComponent.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedComponent.kt
@@ -1,3 +1,10 @@
 package org.gradle.github.dependencygraph.internal.model
 
-data class ResolvedComponent(val id: String, val direct: Boolean, val coordinates: ComponentCoordinates, val repositoryUrl: String?, val dependencies: List<String>)
+data class ResolvedComponent(
+    val id: String,
+    val rootComponent: ResolutionRoot,
+    val direct: Boolean,
+    val coordinates: ComponentCoordinates,
+    val repositoryUrl: String?,
+    val dependencies: List<String>
+)

--- a/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedConfiguration.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependencygraph/internal/model/ResolvedConfiguration.kt
@@ -1,8 +1,9 @@
 package org.gradle.github.dependencygraph.internal.model
 
-data class ResolvedConfiguration(val id: String,
-                                 val identityPath: String,
-                                 val allDependencies: MutableList<ResolvedComponent> = mutableListOf()) {
+data class ResolvedConfiguration(
+    val rootComponent: ResolutionRoot,
+    val allDependencies: MutableList<ResolvedComponent> = mutableListOf()
+) {
     fun addDependency(component: ResolvedComponent) {
         allDependencies.add(component)
     }


### PR DESCRIPTION
This change aims to reduce redundant dependency reporting in repository snapshots, with the aim to make the result work better with the GitHub Dependency Graph. Previously, a dependency was reported for every project that referenced it directly or transitively through a project dependency. This resulted in many dependency versions
 being reported many times within the snapshot, and these duplicates were then mirrored
in the GitHub Dependency Graph and Dependabot Security Alerts.

With this change, only external dependencies are reported, and only within the context of the project that declares those dependencies. This should help reduce the massive redundancy in the generated snapshot and make these files more useful.