### PR TITLE
Improve failure reporting

### DIFF
--- a/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/DependencyExtractorConfigTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/DependencyExtractorConfigTest.groovy
@@ -96,6 +96,6 @@ class DependencyExtractorConfigTest extends BaseExtractorTest {
         def result = executer.runWithFailure()
 
         then:
-        result.output.contains("'GITHUB_DEPENDENCY_GRAPH_JOB_CORRELATOR' must be set")
+        result.output.contains("> The configuration parameter 'GITHUB_DEPENDENCY_GRAPH_JOB_CORRELATOR' must be set")
     }
 }

--- a/plugin/src/main/kotlin/org/gradle/dependencygraph/extractor/DependencyExtractor.kt
+++ b/plugin/src/main/kotlin/org/gradle/dependencygraph/extractor/DependencyExtractor.kt
@@ -12,6 +12,7 @@ import org.gradle.dependencygraph.model.*
 import org.gradle.dependencygraph.util.*
 import org.gradle.initialization.EvaluateSettingsBuildOperationType
 import org.gradle.initialization.LoadProjectsBuildOperationType
+import org.gradle.internal.exceptions.Contextual
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.operations.*
 import java.io.File
@@ -311,11 +312,7 @@ abstract class DependencyExtractor :
         try {
             writeDependencyGraph()
         } catch (e: RuntimeException) {
-            throw GradleException(
-                "The dependency-graph extractor plugin encountered errors while writing the dependency snapshot json file. " +
-                    "Please report this issue at: https://github.com/gradle/github-dependency-graph-gradle-plugin/issues",
-                e
-            )
+            throw DefaultMultiCauseException("Failed to write dependency-graph to file", e)
         }
     }
 

--- a/plugin/src/main/kotlin/org/gradle/dependencygraph/extractor/DependencyExtractor.kt
+++ b/plugin/src/main/kotlin/org/gradle/dependencygraph/extractor/DependencyExtractor.kt
@@ -101,14 +101,16 @@ abstract class DependencyExtractor :
         val details: D? = buildOperation.details.let {
             if (it is D) it else null
         }
-        val result: R? = finishEvent.result.let {
-            if (it is R) it else null
+        if (details == null) {
+            return  // Ignore other build operation types
         }
-        if (details == null && result == null) {
-            return
-        } else if (details == null || result == null) {
-            throw IllegalStateException("buildOperation.details & finishedEvent.result were unexpected types")
+
+        val failure = finishEvent.failure
+        if (failure != null) {
+            throw failure
         }
+
+        val result: R = finishEvent.result as R
         handler(details, result)
     }
 


### PR DESCRIPTION
In certain cases, the exception message reported by Gradle was insufficient or incorrect.
This PR improves a couple of things:

1. Propagate failure received in `FinishEvent`, rather than reporting incorrectly (#103)
2. Use a contextual exception for missing input parameters, to ensure that the underlying cause is correctly reported.