### PR TITLE
Fix dependency vulnerabilities in buildscript classpath

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ jackson-parameter-names = { group = "com.fasterxml.jackson.module", name = "jack
 jackson-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin" }
 
 apache-commons-io = { group = "commons-io", name = "commons-io", version = "2.21.0" }
+apache-tika-core = { group = "org.apache.tika", name = "tika-core", version = "3.2.2" }
+apache-log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version = "2.25.4" }
 
 github-packageurl = { group = "com.github.package-url", name = "packageurl-java", version = "1.5.0" }
 okio = { group = "com.squareup.okio", name = "okio", version = "3.17.0" }
@@ -26,6 +28,6 @@ jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version
 google-gson = { group = "com.google.code.gson", name = "gson", version = "2.13.2" }
 
 [plugins]
-shadow-jar = { id = "com.github.johnrengelman.shadow", version = "8.1.1"}
+shadow-jar = { id = "com.gradleup.shadow", version = "8.3.6"}
 plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.0" }
 github-release = { id = "com.github.breadmoirai.github-release", version = "2.5.2"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,11 +9,9 @@ jackson-parameter-names = { group = "com.fasterxml.jackson.module", name = "jack
 jackson-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin" }
 
 apache-commons-io = { group = "commons-io", name = "commons-io", version = "2.21.0" }
-apache-tika-core = { group = "org.apache.tika", name = "tika-core", version = "3.2.2" }
 apache-log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version = "2.25.4" }
 
 github-packageurl = { group = "com.github.package-url", name = "packageurl-java", version = "1.5.0" }
-okio = { group = "com.squareup.okio", name = "okio", version = "3.17.0" }
 
 ### Test dependencies
 
@@ -30,4 +28,3 @@ google-gson = { group = "com.google.code.gson", name = "gson", version = "2.13.2
 [plugins]
 shadow-jar = { id = "com.gradleup.shadow", version = "8.3.6"}
 plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.0" }
-github-release = { id = "com.github.breadmoirai.github-release", version = "2.5.2"}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -12,10 +12,13 @@ buildscript {
     }
     dependencies {
         constraints {
-            // The plugin com.github.breadmoirai.github-release:2.5.2 depends on vulnerable library releases.
+            // Several plugins on the buildscript classpath (com.github.breadmoirai.github-release:2.5.2,
+            // com.gradleup.shadow) depend on vulnerable library releases.
             // We constrain these to newer, patched versions.
             classpath(libs.okio)
             classpath(libs.apache.commons.io)
+            classpath(libs.apache.tika.core)
+            classpath(libs.apache.log4j.core)
         }
     }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -12,12 +12,9 @@ buildscript {
     }
     dependencies {
         constraints {
-            // Several plugins on the buildscript classpath (com.github.breadmoirai.github-release:2.5.2,
-            // com.gradleup.shadow) depend on vulnerable library releases.
+            // The com.gradleup.shadow plugin depends on vulnerable library releases.
             // We constrain these to newer, patched versions.
-            classpath(libs.okio)
             classpath(libs.apache.commons.io)
-            classpath(libs.apache.tika.core)
             classpath(libs.apache.log4j.core)
         }
     }
@@ -26,7 +23,6 @@ buildscript {
 plugins {
     kotlin("jvm") version(libs.versions.kotlin)
     alias(libs.plugins.plugin.publish)
-    alias(libs.plugins.github.release)
     signing
     groovy
     alias(libs.plugins.shadow.jar)
@@ -210,17 +206,11 @@ val createReleaseTag = tasks.register<CreateGitTag>("createReleaseTag") {
     tagName = releaseTag
 }
 
-githubRelease {
-    setToken(System.getenv("GITHUB_DEPENDENCY_GRAPH_GIT_TOKEN") ?: "")
-    owner = "gradle"
-    repo = "github-dependency-graph-gradle-plugin"
-    releaseName = releaseVersion
-    tagName = releaseTag
-    body = releaseNotes
-}
-
-tasks.named("githubRelease").configure {
+tasks.register<CreateGitHubRelease>("githubRelease") {
     dependsOn(createReleaseTag)
+    tagName = releaseTag
+    releaseName = releaseVersion
+    notesFile = rootProject.layout.projectDirectory.file("release/changes.md")
 }
 
 tasks.withType(PublishTask::class).configureEach {
@@ -241,6 +231,32 @@ abstract class CreateGitTag : DefaultTask() {
         }
         execOperations.exec {
             commandLine("git", "push", "origin", "-f", "--tags")
+        }
+    }
+}
+
+abstract class CreateGitHubRelease : DefaultTask() {
+
+    @get:Input abstract val tagName: Property<String>
+
+    @get:Input abstract val releaseName: Property<String>
+
+    @get:InputFile abstract val notesFile: RegularFileProperty
+
+    @get:Inject abstract val execOperations: ExecOperations
+
+    @TaskAction
+    fun action() {
+        val tag = tagName.get()
+        logger.info("Creating GitHub release ${releaseName.get()} for tag $tag")
+        execOperations.exec {
+            commandLine(
+                "gh", "release", "create", tag,
+                "--title", releaseName.get(),
+                "--notes-file", notesFile.get().asFile.absolutePath
+            )
+            // The github-release workflow provides the token via this environment variable.
+            environment("GH_TOKEN", System.getenv("GITHUB_DEPENDENCY_GRAPH_GIT_TOKEN") ?: "")
         }
     }
 }


### PR DESCRIPTION
## Summary

Resolves 5 open Dependabot alerts for vulnerable transitive dependencies on the plugin buildscript classpath (alerts 21, 22, 25, 26, 27). The 6 `com.fasterxml.jackson.core` alerts are intentionally left untouched.

## Changes

- **Update the Shadow plugin** from `com.github.johnrengelman.shadow:8.1.1` to `com.gradleup.shadow:8.3.6`, which pulls `plexus-utils` up to `4.0.2`, clearing that alert with no constraint. (Alert 25)
- **Remove the `com.github.breadmoirai.github-release:2.5.2` plugin.** It was used only to create a bare GitHub release (no asset uploads), yet it was the sole source of `tika-core` and `okio` on the classpath. Its only patched version, `tika-core:3.2.2`, requires **JDK 11** and cannot load on the JDK 8 the build runs on in the CI matrix. It's replaced by a small `CreateGitHubRelease` task that shells out to `gh release create`, keeping the `githubRelease` task name so the external release workflow is unaffected. This removes `tika-core` and `okio` entirely. (Alert 21)
- **Constrain the remaining vulnerable transitive of the Shadow plugin** to a patched version (alerts 22, 26, 27):

  | Library | Resolved before | Now |
  |---|---|---|
  | `org.apache.logging.log4j:log4j-core` | 2.24.1 | **2.25.4** |

  (`commons-io` stays pinned at 2.21.0 — a pre-existing pin, not tied to any of these alerts.)

## Why remove github-release rather than pin Tika?

Tika 3.x is Java 11 bytecode, and Dependabot offers no patched 2.x. Since the build runs on JDK 8 in the `test-gradle-version` matrix, a patched Tika on the buildscript classpath is a JDK-8 landmine. The plugin created only a bare release, so Tika served no functional purpose — removing the plugin is the smallest change that both clears the CVEs and eliminates the JDK-8 conflict, rather than working around it.

## Verification

- Resolved buildscript classpath confirms `tika-core` and `okio` are gone; `plexus-utils:4.0.2`, `log4j-core → 2.25.4`, `commons-io → 2.21.0`.
- `:plugin:build`, `:plugin:shadowJar`, and `:plugin:test` all pass.
- The new `githubRelease` task resolves, wires `dependsOn(createReleaseTag)`, and configures cleanly under the configuration cache (`--dry-run` verified).

## Note for the release workflow

The replacement task relies on the `gh` CLI (preinstalled on GitHub runners) and reads the token from the existing `GITHUB_DEPENDENCY_GRAPH_GIT_TOKEN` env var (mapped to `GH_TOKEN`). The `gh release create` path is not exercised by CI, so it's worth confirming during the next staging release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)