### PR TITLE
Upgrade Jackson to 2.18.8 and drop jackson-module-kotlin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,9 @@ spock = "2.4-groovy-3.0"
 kotlin = "1.8.10"
 
 [libraries]
-jackson-platform = { group = "com.fasterxml.jackson", name = "jackson-bom", version = "2.14.2" } # Cannot upgrade to 2.15.x, due to https://github.com/gradle/gradle/issues/24390
+jackson-platform = { group = "com.fasterxml.jackson", name = "jackson-bom", version = "2.18.8" }
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind" }
 jackson-parameter-names = { group = "com.fasterxml.jackson.module", name = "jackson-module-parameter-names" }
-jackson-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin" }
 
 apache-commons-io = { group = "commons-io", name = "commons-io", version = "2.21.0" }
 apache-log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version = "2.25.4" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -46,13 +46,6 @@ dependencies {
     compileOnly(kotlin("reflect"))
     shadowImplementation(platform(libs.jackson.platform))
     shadowImplementation(libs.jackson.databind)
-    shadowImplementation(libs.jackson.kotlin) {
-        version {
-            strictly("2.12.3")
-        }
-        exclude(group = "org.jetbrains.kotlin")
-        because("kotlin std lib is bundled with Gradle. 2.12.3 because higher versions depend upon Kotlin 1.5")
-    }
     shadowImplementation(libs.github.packageurl)
 
     // Use JUnit Jupiter for testing.
@@ -92,6 +85,12 @@ tasks.withType<PluginUnderTestMetadata>().configureEach {
 
 val shadowJarTask = tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier = ""
+    // Strip multi-release class files (Jackson ships JDK 11/17/21 optimized variants under
+    // META-INF/versions). Older Gradle versions bundle an ASM that cannot read these newer
+    // class file versions when they instrument the plugin classpath, failing with
+    // "Unsupported class file major version". The Java 8 base classes work on all supported
+    // Gradle versions. See https://github.com/gradle/gradle/issues/24390
+    exclude("META-INF/versions/**")
     configurations = listOf(shadowImplementation)
     val projectGroup = project.group
     doFirst {

--- a/plugin/src/main/kotlin/org/gradle/dependencygraph/util/JacksonJsonSerializer.kt
+++ b/plugin/src/main/kotlin/org/gradle/dependencygraph/util/JacksonJsonSerializer.kt
@@ -1,13 +1,12 @@
 package org.gradle.dependencygraph.util
 
-import com.fasterxml.jackson.module.kotlin.jsonMapper
-import com.fasterxml.jackson.module.kotlin.kotlinModule
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.json.JsonMapper
 
 object JacksonJsonSerializer {
-    private val mapper = jsonMapper {
-        serializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-        addModule(kotlinModule())
-    }
+    private val mapper = JsonMapper.builder()
+        .serializationInclusion(JsonInclude.Include.NON_NULL)
+        .build()
 
     fun serializeToJson(dependencyGraph: Any): String {
         return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(dependencyGraph)


### PR DESCRIPTION
## What

Upgrades the Jackson BOM from **2.14.2 → 2.18.8** to fix the outstanding `jackson-core` / `jackson-databind` CVEs, and removes the `jackson-module-kotlin` dependency that was the real blocker to upgrading.

This is a clean, minimal alternative to #215 — it fixes the same CVEs without the test failures that #215 hit on older Gradle versions.

| Package | ID | Fixed |
|---|---|---|
| jackson-core | CVE-2025-52999 | ✅ |
| jackson-core | GHSA-72hv-8253-57qq | ✅ |
| jackson-databind | CVE-2026-54512 | ✅ |
| jackson-databind | CVE-2026-54513 | ✅ |
| jackson-databind | CVE-2026-54514 | ✅ |

## Why the previous approach failed on old Gradle

`jackson-module-kotlin` ≥ 2.13 calls a **Kotlin 1.5** reflection API (`KClass.isValue()`) during introspection. Because the module excludes the Kotlin stdlib and relies on the Kotlin bundled inside Gradle at runtime, the plugin failed on Gradle **5.2–7.2** (which bundle Kotlin 1.3/1.4) with:

```
Failed to notify build listener.
> 'boolean kotlin.reflect.KClass.isValue()'
```

That — not the multi-release jar — was the cause of the old-Gradle failures in #215. (This is why the module was originally pinned to `2.12.3` "because higher versions depend upon Kotlin 1.5".)

## The fix

- **Drop `jackson-module-kotlin` entirely.** It is only needed for *deserialization*; this plugin only ever *serializes* (`writeValueAsString`), and Jackson's default bean serializer handles the Kotlin `data class`es via their generated getters. `JacksonJsonSerializer` now uses a plain `JsonMapper`.
- **Strip `META-INF/versions/**` from the shaded jar.** Jackson 2.15+ is a multi-release jar with JDK 11/17/21-optimized classes; older Gradle's bundled ASM can't read those newer class file versions when instrumenting the plugin classpath ([gradle/gradle#24390](https://github.com/gradle/gradle/issues/24390)) and fails with *"Unsupported class file major version"*. The Java 8 base classes work everywhere. Stripping all versioned entries (rather than just 17/21) is robust against future JDK-specific variants.

The `com.gradleup.shadow` migration this depends on already landed on `main` in #217.

## Verification

Ran the functional test suite locally against previously-failing combinations:

- ✅ Full `:plugin-test:test` on **Gradle 6.9.4 / JDK 11** and **7.1.1 / JDK 11** (both previously failed with the Kotlin error) — pass.
- ✅ **Gradle 5.2.1 / 5.6.4 on JDK 8** — no `NoSuchMethodError` and no *"Unsupported class file major version"* (the shaded jar loads and the plugin runs).
- ✅ JSON-schema validation and exact property-name assertions in the suite confirm serialized output is unchanged without the Kotlin module.

Closes #215 (supersedes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)