### PR TITLE
Add aggregate test-gradle-versions status check

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -76,6 +76,20 @@ jobs:
       - name: Execute Gradle Build
         run: ./gradlew -S build -DtestGradleVersion=${{ matrix.gradle-version }}
 
+  # Aggregates the test-gradle-version matrix into a single status check.
+  # Enable "merge when checks pass" / branch protection against this job rather than
+  # the individual matrix jobs, whose names change whenever the matrix is edited.
+  test-gradle-versions:
+    needs: test-gradle-version
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all matrix jobs succeeded
+        if: ${{ needs.test-gradle-version.result != 'success' }}
+        run: |
+          echo "test-gradle-version matrix result: ${{ needs.test-gradle-version.result }}"
+          exit 1
+
   self-test:
     needs: quick-check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a single `test-gradle-versions` job that depends on the entire `test-gradle-version` matrix.

## Why

To enable **"merge when checks pass"** / branch protection, you need to mark specific status checks as *required*. Requiring the matrix jobs individually is brittle — their check names (`test-gradle-version (5.2.1, 8)`, etc.) change every time the matrix is edited, silently dropping the protection. This aggregate job gives a single, stable check name to require.

## How it works

```yaml
test-gradle-versions:
  needs: test-gradle-version
  if: ${{ always() }}
  runs-on: ubuntu-latest
  steps:
    - name: Verify all matrix jobs succeeded
      if: ${{ needs.test-gradle-version.result != 'success' }}
      run: |
        echo "test-gradle-version matrix result: ${{ needs.test-gradle-version.result }}"
        exit 1
```

- `needs.test-gradle-version.result` aggregates **all** matrix combinations — it is `success` only if every one passed.
- `if: always()` ensures the gate still runs when a matrix job fails (otherwise a `needs` job is *skipped*, which would never satisfy a required check and would block merges indefinitely).
- The step then fails the gate unless the aggregated result is `success`, so any failed or cancelled matrix job propagates.

## Follow-up

After this merges, add `test-gradle-versions` (and `quick-check` / `self-test` as desired) to the required status checks in the branch protection rule for `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)