### PR TITLE
Support signing with a PGP subkey

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -153,6 +153,7 @@ signing {
     setRequired({ gradle.taskGraph.hasTask(":plugin:publishPlugins") })
 
     useInMemoryPgpKeys(
+        providers.environmentVariable("PGP_SIGNING_KEY_ID").orNull,
         providers.environmentVariable("PGP_SIGNING_KEY").orNull,
         providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
     )


### PR DESCRIPTION
Allows the publication signing key to be a signing **subkey** rather than the primary key, so the primary can be kept offline.

Gradle's `signing` plugin needs the 3-argument `useInMemoryPgpKeys(keyId, key, passphrase)` overload to select a subkey — the 2-argument form always uses the primary key. This reads the id from a new `PGP_SIGNING_KEY_ID` environment variable.

**Backwards compatible, safe to merge before the variable is set.** Gradle documents `keyId` as nullable: *"optional if keyring contains only one master key, and it should be used"*. While `PGP_SIGNING_KEY_ID` is unset, signing behaves exactly as it does today.

Note for whoever sets it: it must be the **8-character short** key id. Gradle's `PgpKeyId` accepts only 8 hex characters (or 10 with a `0x` prefix) and throws `"The key ID must be in a valid form"` on a 16-character long id.