### PR TITLE
Update trusted-key for the rotated Gradle Inc. signing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,17 @@ However, if this doesn't work, you can add the following to your `dependency-ver
 
 ```xml
 <trusted-keys>
-   <trusted-key id="7B79ADD11F8A779FE90FD3D0893A028475557671" group="org.gradle" name="github-dependency-graph-gradle-plugin"/>
+   <trusted-key id="E2879931BCA1A42E55F2D64DD9B2DFBD9F3298BA" group="org.gradle" name="github-dependency-graph-gradle-plugin"/>
 </trusted-keys>
 ```
+
+Releases from 1.5.0 onward are signed with the `Gradle Inc. <info@gradle.com>` signing subkey
+`E2879931BCA1A42E55F2D64DD9B2DFBD9F3298BA`, belonging to primary key `15D543CA40743FFA47654C16622DE19DC011B9BE`.
+This key is published to `keys.openpgp.org`.
+
+Releases up to and including 1.4.2 were signed with the previous key `7B79ADD11F8A779FE90FD3D0893A028475557671`,
+which was revoked on 2026-08-17 as superseded. If you verify one of those releases, you will need to trust
+that key instead.
 
 ## Using the plugin to generate dependency reports
 


### PR DESCRIPTION
The PGP key documented in the README for [dependency verification](https://github.com/gradle/github-dependency-graph-gradle-plugin#dependency-verification), `7B79ADD11F8A779FE90FD3D0893A028475557671`, was **revoked on 2026-08-17** with reason "Key is superseded". The documented snippet will not verify releases from 1.5.0 onward.

## What changed

Releases are now signed by the `Gradle Inc. <info@gradle.com>` **signing subkey**:

```
pub   rsa4096 2026-08-17 [C]  15D543CA40743FFA47654C16622DE19DC011B9BE
uid                           Gradle Inc. <info@gradle.com>
sub   rsa4096 2026-08-17 [S]  E2879931BCA1A42E55F2D64DD9B2DFBD9F3298BA
```

The primary key is certify-only `[C]` and cannot sign, so signing must go through the subkey — which is why #228 added `PGP_SIGNING_KEY_ID` to `useInMemoryPgpKeys`.

## Verification

Confirmed against a staging publish (`1.5.0-signing-check-1`), with both Gradle 8.14.4 and 9.7.1, in a consumer project with an isolated `GRADLE_USER_HOME`:

| Check | Result |
| --- | --- |
| `gpg --verify` on the staged jar | Good signature from `Gradle Inc. <info@gradle.com>`, key id `D9B2DFBD9F3298BA` |
| `--write-verification-metadata pgp,sha256` | emits `<trusted-key id="E2879931BCA1A42E55F2D64DD9B2DFBD9F3298BA" .../>` |
| Snippet as written in this PR | resolves, verification passes |
| Primary key fingerprint instead | fails — 2 artifacts (`.jar` and `.module`) |

The failure with the primary key confirms Gradle matches the signing subkey fingerprint and does not accept the primary as a stand-in:

> Artifact was signed with key `E2879931BCA1A42E55F2D64DD9B2DFBD9F3298BA` (Gradle Inc. \<info@gradle.com>) but this key is not in your trusted key list

## Follow-up for whoever manages the key

The new key is published to `keys.openpgp.org` but is **not** on `keyserver.ubuntu.com` (direct fingerprint lookup 404s). Both are in Gradle's default keyserver list, so verification works today — but the redundancy the old key had is gone. Worth uploading.