### PR TITLE
Update GitHub Actions and pin them to commit SHAs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,16 +15,16 @@ jobs:
   quick-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
             java-version: 17
             distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
@@ -63,19 +63,19 @@ jobs:
             java-version: "21"        
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Fixed build JDK: compiles the plugin and builds the shadow fatjar. Must satisfy the build
       # tooling's own JDK requirement (the shadow plugin needs Java 17+), independent of the older
       # JDK the Gradle version under test runs on.
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: 17
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
@@ -109,16 +109,16 @@ jobs:
     permissions:
       contents: write # Required to submit the dependency graph snapshot to GitHub
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
             java-version: 17
             distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
@@ -133,7 +133,7 @@ jobs:
             GITHUB_DEPENDENCY_GRAPH_WORKSPACE: ${{ github.workspace }}
 
       - name: Save plugin JSON report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: plugin-json
             path: build/reports/dependency-graph-snapshots/plugin-self-test.json


### PR DESCRIPTION
Bumps the actions used by the CI workflow and pins every one to a full commit SHA, with the release version recorded in a trailing comment.

| Action | Was | Now | SHA |
|---|---|---|---|
| `actions/setup-java` | v5 | v6.0.0 | `dd06d9cb…` |
| `gradle/actions/setup-gradle` | v6 | v6.3.0 | `9c971963…` |
| `actions/checkout` | v7 | v7.0.1 | `3d3c42e5…` |
| `actions/upload-artifact` | v7 | v7.0.1 | `043fb46d…` |

Version tags are mutable, so a tag pin lets a compromised or force-pushed tag change what CI executes. Each SHA was resolved through the GitHub API and is the exact commit its release tag points at.

Dependabot updates SHA pins and their version comments in place, so the existing `github-actions` entry in `.github/dependabot.yml` keeps working unchanged — no config change needed.

Note on `gradle/actions`: #227 proposed v6.2.0, but the `v6` tag now resolves to v6.3.0, so this picks up the current release rather than pinning a superseded one.

Supersedes #229 and #227, which are closed in favour of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)